### PR TITLE
Window facade shutdown Connects #40

### DIFF
--- a/Ewe/main.cpp
+++ b/Ewe/main.cpp
@@ -26,6 +26,5 @@ int main ( ) {
   tm.start();
 
   tm.listen ( );
-
   return 0;
 }

--- a/command_manager/CommandManager.h
+++ b/command_manager/CommandManager.h
@@ -16,10 +16,10 @@ namespace command_manager {
   };
 
   enum CommandType {
-    // ONLY FOR WINDOW_FACADE!! if you wan't to shutdown system use KILL_WINDOW.
+    // ONLY FOR WINDOW_FACADE!! if you wan't to shutdown system use KILL.
     DESTROY_ALL,
-    // Any thread send KILL_WINDOW, ThreadManager send it to WindowFacade, WindowFacade after shutdown send DESTROY_ALL
-    KILL_WINDOW,
+    // Any thread send KILL, ThreadManager send it to WindowFacade, WindowFacade after shutdown send DESTROY_ALL
+    KILL,
     PAUSE,
     RESUME,
     INITIALIZE,

--- a/command_manager/CommandManager.h
+++ b/command_manager/CommandManager.h
@@ -16,7 +16,10 @@ namespace command_manager {
   };
 
   enum CommandType {
-    KILL,
+    // ONLY FOR WINDOW_FACADE!! if you wan't to shutdown system use KILL_WINDOW.
+    DESTROY_ALL,
+    // Any thread send KILL_WINDOW, ThreadManager send it to WindowFacade, WindowFacade after shutdown send DESTROY_ALL
+    KILL_WINDOW,
     PAUSE,
     RESUME,
     INITIALIZE,

--- a/system/WindowFacade.cpp
+++ b/system/WindowFacade.cpp
@@ -21,12 +21,12 @@ ID WindowFacade::id() {
   return ID::WINDOW_FACADE;
 }
 
-WindowFacade* window_facade::WindowFacade::getInstance() {
+WindowFacade* WindowFacade::getInstance() {
   static WindowFacade* facade = new WindowFacade();
   return facade;
 }
 
-window_facade::WindowFacade::WindowFacade() {
+WindowFacade::WindowFacade() {
   log = new utils::Logger(typeid(*this).name());
 
   _name = appName;
@@ -41,11 +41,11 @@ window_facade::WindowFacade::WindowFacade() {
   _hwnd = 0;
 }
 
-window_facade::WindowFacade::~WindowFacade() {
+WindowFacade::~WindowFacade() {
   delete log;
 }
 
-void window_facade::WindowFacade::_send(command_manager::Command& c) {
+void WindowFacade::_send(command_manager::Command& c) {
   _commandManager->push(c);
 }
 
@@ -268,20 +268,20 @@ bool WindowFacade::_additionalInitialize() {
   };
 
   if (!(_hDC = GetDC(_hwnd))) {
+    log->fatal("Can't Create A GL Device Context.");
     _shutdown();
-    // TODO: Log "WindowFacade: Can't Create A GL Device Context."
     return false;
   }
 
   if (!(PixelFormat = ChoosePixelFormat(_hDC, &pfd))) {
+    log->fatal("Can't Find A Suitable PixelFormat.");
     _shutdown();
-    // TODO: Log "WindowFacade: Can't Find A Suitable PixelFormat."
     return false;
   }
 
   if (!SetPixelFormat(_hDC, PixelFormat, &pfd)) {
+    log->fatal("Can't Set The PixelFormat.");
     _shutdown();
-    // TODO: Log "WindowFacade: Can't Set The PixelFormat."
     return false;
   }
   return true;
@@ -296,10 +296,8 @@ void WindowFacade::_shutdown() {
       log->fatal("Release Device Context Failed.");
       _hDC = NULL;
     }
-   if(!DestroyWindow(_hwnd)) {
-     DWORD problem = GetLastError();
+   if(!DestroyWindow(_hwnd)) 
       log->fatal("DestroyWindow was failed");
-    }
    _hwnd = NULL;
   }
   if (!UnregisterClass(_wndClassName.c_str(), GetModuleHandle(NULL))) {
@@ -313,25 +311,25 @@ void WindowFacade::_shutdown() {
 }
 
 void WindowFacade::pp_setMinimized(bool minimized) {
-  _minimized = minimized;
+  this->_minimized = minimized;
 }
 
 bool WindowFacade::pp_getMinimized() {
-  return _minimized;
+  return this->_minimized;
 }
 
 void WindowFacade::_sendHwnd() {
-  Command hwndToGraphic = Command( this->id(), ID::GRAPHIC, INITIALIZE);
+  Command hwndToGraphic = Command(this->id(), ID::GRAPHIC, INITIALIZE);
 #if defined(__DX_GRAPHIC)
   hwndToGraphic.args[0] = reinterpret_cast<int>(_hwnd);
 #elif defined(__GL_GRAPHIC)
   hwndToGraphic.args[0] = reinterpret_cast<int>(_hDC);
 #endif
-  hwndToGraphic.args[1] = _width;
-  hwndToGraphic.args[2] = _height;
+  hwndToGraphic.args[1] = this->_width;
+  hwndToGraphic.args[2] = this->_height;
   _send(hwndToGraphic);
 
-  Command hwndToIO = Command( this->id(), ID::IO, INITIALIZE);
+  Command hwndToIO = Command(this->id(), ID::IO, INITIALIZE);
   hwndToIO.args[0] = reinterpret_cast<int>(_hwnd);
   _send(hwndToIO);
 
@@ -341,29 +339,29 @@ void WindowFacade::_sendHwnd() {
 }
 
 void WindowFacade::pp_sendPause() {
-  Command commandPause = Command(id(), ID::THREAD_MANAGER, PAUSE);
+  Command commandPause = Command(this->id(), ID::THREAD_MANAGER, PAUSE);
   _send(commandPause);
 }
 
 void WindowFacade::pp_sendResume() {
-  Command commandResume = Command(id(), ID::THREAD_MANAGER, RESUME);
+  Command commandResume = Command(this->id(), ID::THREAD_MANAGER, RESUME);
   _send(commandResume);
 }
 
-void window_facade::WindowFacade::pp_sendKill() {
+void WindowFacade::pp_sendKill() {
   _sendKill();
 }
 
-void window_facade::WindowFacade::pp_sendResize(int width, int height) {
-  _width = width;
-  _height = height;
-  Command commandResize = Command(id(), ID::GRAPHIC, RESIZE);
-  commandResize.args[0] = width;
-  commandResize.args[1] = height;
+void WindowFacade::pp_sendResize(int width, int height) {
+  this->_width = width;
+  this->_height = height;
+  Command commandResize = Command(this->id(), ID::GRAPHIC, RESIZE);
+  commandResize.args[0] = this->_width;
+  commandResize.args[1] = this->_height;
   _send(commandResize);
 }
 
 void WindowFacade::_sendDestroyAll() {
-  Command cmndRealKill = Command(id(), ID::THREAD_MANAGER, DESTROY_ALL);
+  Command cmndRealKill = Command(this->id(), ID::THREAD_MANAGER, DESTROY_ALL);
   _commandManager->push(cmndRealKill);
 }

--- a/system/WindowFacade.cpp
+++ b/system/WindowFacade.cpp
@@ -68,7 +68,7 @@ void WindowFacade::stop() {
 
 void WindowFacade::_processCommand(command_manager::Command& c) {
   switch (c.commandType) {
-  case KILL_WINDOW: 
+  case KILL: 
     _shutdown();
     _sendDestroyAll();
     break;
@@ -319,7 +319,6 @@ void WindowFacade::pp_setMinimized(bool minimized) {
 bool WindowFacade::pp_getMinimized() {
   return _minimized;
 }
-
 
 void WindowFacade::_sendHwnd() {
   Command hwndToGraphic = Command( this->id(), ID::GRAPHIC, INITIALIZE);

--- a/system/WindowFacade.h
+++ b/system/WindowFacade.h
@@ -3,6 +3,7 @@
 
 #include <ThreadManager.h>
 #include <Windows.h>
+#include <Logger.h>
 
 #include <Logger.h>
 
@@ -34,6 +35,7 @@ namespace window_facade {
     WindowFacade();
     WindowFacade(WindowFacade&);
     void _generateCommandProcessors();
+    void _sendDestroyAll();
 
   private:
     void _sendHwnd();
@@ -52,6 +54,7 @@ namespace window_facade {
     std::string _wndClassName;
     bool _fullscreen;
     bool _minimized;
+    bool _initialized;
   };
 
 }

--- a/thread_manager/ThreadManager.cpp
+++ b/thread_manager/ThreadManager.cpp
@@ -41,7 +41,7 @@ namespace thread_manager {
   void ThreadSubjectWithKill::_sendKill() {
     Command commandKill = Command(
       this->id(), ID::THREAD_MANAGER,
-      CommandType::KILL);
+      CommandType::KILL_WINDOW);
     _commandManager->push(commandKill);
   }
 
@@ -62,7 +62,7 @@ namespace thread_manager {
 
   void ThreadManager::start() {
     // don't replace to for(auto c : _subjects)
-    for (auto c = _subjects.begin(); c != _subjects.end(); c++){
+    for (auto c = _subjects.begin(); c != _subjects.end(); c++) {
       auto value = *c;
       _threads.push_back(thread([&value]() { value->start(); }));
 
@@ -97,10 +97,12 @@ namespace thread_manager {
       while (this->_commands->size() > 0) {
         auto& c = this->_commands->front();
         switch (c.commandType) {
-
-        case CommandType::KILL:
+        case CommandType::DESTROY_ALL:
           this->stop();
           return;
+        case CommandType::KILL_WINDOW:
+          _sendKillWindow();
+          break;
 
         case CommandType::PAUSE:
           this->pause();
@@ -115,6 +117,11 @@ namespace thread_manager {
         this->_commands->pop();
       }
     }
+  }
+
+  void ThreadManager::_sendKillWindow() {
+    Command cmndKill = Command(ID::THREAD_MANAGER, ID::WINDOW_FACADE, CommandType::KILL_WINDOW);
+    _commandManager.push(cmndKill);
   }
 
 }

--- a/thread_manager/ThreadManager.cpp
+++ b/thread_manager/ThreadManager.cpp
@@ -40,8 +40,8 @@ namespace thread_manager {
 
   void ThreadSubjectWithKill::_sendKill() {
     Command commandKill = Command(
-      this->id(), ID::THREAD_MANAGER,
-      CommandType::KILL_WINDOW);
+      this->id(), ID::WINDOW_FACADE,
+      CommandType::KILL);
     _commandManager->push(commandKill);
   }
 
@@ -97,10 +97,12 @@ namespace thread_manager {
       while (this->_commands->size() > 0) {
         auto& c = this->_commands->front();
         switch (c.commandType) {
+
         case CommandType::DESTROY_ALL:
           this->stop();
           return;
-        case CommandType::KILL_WINDOW:
+
+        case CommandType::KILL:
           _sendKillWindow();
           break;
 
@@ -120,7 +122,7 @@ namespace thread_manager {
   }
 
   void ThreadManager::_sendKillWindow() {
-    Command cmndKill = Command(ID::THREAD_MANAGER, ID::WINDOW_FACADE, CommandType::KILL_WINDOW);
+    Command cmndKill = Command(ID::THREAD_MANAGER, ID::WINDOW_FACADE, CommandType::KILL);
     _commandManager.push(cmndKill);
   }
 

--- a/thread_manager/ThreadManager.h
+++ b/thread_manager/ThreadManager.h
@@ -45,6 +45,8 @@ private:
 
   command_manager::CommandManager _commandManager;
   std::shared_ptr<std::queue<command_manager::Command>> _commands;
+
+  void _sendKillWindow();
 public:
   ThreadManager ( );
 


### PR DESCRIPTION
Destroy ( HWND ) и UnregisterClass должны происходить В ТОМ потоке, который их породил. поэтому, если кто-то захочет убить приложение, он должен отправить сообщение KILL WindowFacad'у ( _sendKill() ), подразумевая убийство всей системы. WindowFacade корректно убивает себя в своём потоке и отправляет сообщение DESTROY_ALL и система останавливается (все потоки на стоп  и тд).

