### PR TITLE
Connects #104 to monothread system

### DIFF
--- a/Ewe/src/main.cpp
+++ b/Ewe/src/main.cpp
@@ -23,8 +23,8 @@ int main ( ) {
   tm.add(&sound);
   tm.add(window);
 
-  tm.start();
+  tm.startMono(); //tm.start();
+  tm.listenMono(); //tm.listen();
 
-  tm.listen ( );
   return 0;
 }

--- a/Ewe/src/main.cpp
+++ b/Ewe/src/main.cpp
@@ -23,8 +23,10 @@ int main ( ) {
   tm.add(&sound);
   tm.add(window);
 
-  tm.startMono(); //tm.start();
-  tm.listenMono(); //tm.listen();
+  if(tm.startMono()) { 
+    // TODO: Init smthing
+    tm.listenMono(); 
+  }
 
   return 0;
 }

--- a/graphic/src/Graphic.cpp
+++ b/graphic/src/Graphic.cpp
@@ -10,6 +10,8 @@ static const int graphicSleep = 100;
 
 command_manager::ID graphic::Graphic::id() {
   return command_manager::ID::GRAPHIC;
+  _initialized = false;
+  _sleepThread = graphicSleep;
 }
 
 Graphic::Graphic ( ) {
@@ -62,19 +64,12 @@ void Graphic::_processCommand (command_manager::Command& c) {
   return;
 }
 
-void Graphic::start() {
-  log->info("thread was started");
-
-  while (!this->_willStop) {
-    auto a = std::chrono::milliseconds(graphicSleep);
-    std::this_thread::sleep_for (a);
-
-    if (_initialized && !_paused) {
-      _beginScene();
-      _drawContent();
-      _endScene();
-    }
-
-    _processCommands ( );
+void Graphic::processTick() {
+  if (_initialized && !_paused) {
+    _beginScene();
+    _drawContent();
+    _endScene();
   }
+
+  _processCommands ( );
 }

--- a/graphic/src/Graphic.h
+++ b/graphic/src/Graphic.h
@@ -16,8 +16,9 @@ namespace graphic {
     Graphic();
     ~Graphic();
 
+    void processTick() override final;
+
     void stop() override final;
-    void start() override final;
     void pause() override final;
     void resume() override final;
   };

--- a/graphic/src/graphicFacade/IGraphicFacade.h
+++ b/graphic/src/graphicFacade/IGraphicFacade.h
@@ -13,9 +13,10 @@ namespace graphic {
     virtual void _shutdown() = 0;
     virtual bool _addModel(const char*) = 0;
 
-    bool _initialized;
     int _sizeX;
     int _sizeY;
+
+    bool _initialized;
   };
 
 }

--- a/io/src/IO.cpp
+++ b/io/src/IO.cpp
@@ -9,6 +9,7 @@ static const int ioSleep = 100;
 
 command_manager::ID IO::id() {
   return command_manager::ID::IO;
+  _sleepThread = ioSleep;
 }
 
 IO::IO() { 
@@ -21,28 +22,20 @@ IO::~IO() {
   delete log;
 }
 
-void IO::start() {
-  log->info("IO thread was started");
-
-  while (!this->_willStop) {
-    auto a = std::chrono::milliseconds(ioSleep);
-    std::this_thread::sleep_for(a);
-
-    _processCommands();
+void IO::processTick() {
+  _processCommands();
     
-    if (_paused || !_initialized) 
-      continue;
+  if (_paused || !_initialized) return;
 
-    _update();
+  _update();
 
-    /*
-    How To use system:
-    if (_pressed(IO_KEY_W)) 
-      cout << "W pressed!\n";
-    if (_pressed(IO_KEY_A)) 
-      cout << "A pressed!\n";
-      */
-  }
+  /*
+  How To use system:
+  if (_pressed(IO_KEY_W)) 
+    cout << "W pressed!\n";
+  if (_pressed(IO_KEY_A)) 
+    cout << "A pressed!\n";
+    */
 }
 
 void IO::stop() {

--- a/io/src/IO.cpp
+++ b/io/src/IO.cpp
@@ -9,12 +9,11 @@ static const int ioSleep = 100;
 
 command_manager::ID IO::id() {
   return command_manager::ID::IO;
-  _sleepThread = ioSleep;
 }
 
 IO::IO() { 
   _initialized = false;
-
+  _sleepThread = ioSleep;
   log = new utils::Logger(typeid(*this).name());
 }
 

--- a/io/src/IO.h
+++ b/io/src/IO.h
@@ -18,10 +18,10 @@ namespace io {
     IO();
     ~IO();
 
-    void stop();
-    void start();
-    void pause();
-    void resume();
+    void processTick() override final;
+    void stop() override final;
+    void pause() override final;
+    void resume() override final;
   };
 
 }

--- a/logic/src/Logic.cpp
+++ b/logic/src/Logic.cpp
@@ -12,6 +12,7 @@ command_manager::ID Logic::id() {
 
 Logic::Logic() {
   log = new utils::Logger(typeid(*this).name());
+  _sleepThread = logicSleep;
 }
 
 Logic::~Logic() {
@@ -35,15 +36,10 @@ void Logic::stop() {
   this->_willStop = true;
 }
 
-void Logic::start() {
-  log->info("Logic thread was started");
+void Logic::processTick() {
+  if(_paused) return;
 
-  while (!this->_willStop) {
-    auto a = std::chrono::milliseconds(logicSleep);
-    std::this_thread::sleep_for (a);
-
-    _processCommands ();
-  }
+  _processCommands ();
 }
 
 void Logic::pause() {

--- a/logic/src/Logic.h
+++ b/logic/src/Logic.h
@@ -8,20 +8,20 @@
 
 namespace logic {
 
-class Logic : public thread_manager::ThreadSubject {
-  utils::Logger* log;
+  class Logic : public thread_manager::ThreadSubject {
+    utils::Logger* log;
 
-  void _processCommand (command_manager::Command& c);
-public:
-  command_manager::ID id();
-  Logic();
-  ~Logic();
+    void _processCommand (command_manager::Command& c);
+  public:
+    command_manager::ID id();
+    Logic();
+    ~Logic();
 
-  void stop();
-  void start();
-  void pause();
-  void resume();
-};
+    void processTick() override final;
+    void stop() override final;
+    void pause() override final;
+    void resume() override final;
+  };
 
 }
 

--- a/sound/src/Sound.cpp
+++ b/sound/src/Sound.cpp
@@ -12,6 +12,7 @@ command_manager::ID Sound::id() {
 
 Sound::Sound() {
   log = new utils::Logger(typeid(*this).name());
+  _sleepThread = soundSleep;
 }
 
 Sound::~Sound() {
@@ -44,16 +45,10 @@ void Sound::stop() {
   this->_willStop = true;
 }
 
-void Sound::start() {
-  log->info("Sound thread was started");
+void Sound::processTick() {
+  if(_paused) return;
 
-  while (!this->_willStop) {
-    auto a = std::chrono::milliseconds(soundSleep);
-    std::this_thread::sleep_for (a);
-
-    // TODO: check all audios for end & remove if;
-    _processCommands ();
-  }
+  _processCommands();
 }
 
 void Sound::pause() {

--- a/sound/src/Sound.h
+++ b/sound/src/Sound.h
@@ -17,8 +17,8 @@ namespace sound {
     Sound();
     ~Sound();
 
+    void processTick() override final;
     void stop() override final;
-    void start() override final;
     void pause() override final;
     void resume() override final;
   };

--- a/system/src/WindowFacade.h
+++ b/system/src/WindowFacade.h
@@ -20,8 +20,9 @@ namespace window_facade {
   public:
     ~WindowFacade();
     command_manager::ID id();
+    bool initialize() override final;
+    void processTick() override final;
     void stop() override final;
-    void start() override final;
     void pause() override final;
     void resume() override final;
 
@@ -39,7 +40,7 @@ namespace window_facade {
     void _sendDestroyAll();
 
   private:
-    void _sendHwnd();
+    void _sendInitialize();
     void _send(command_manager::Command& c);
     bool _initialize();
     bool _additionalInitialize();

--- a/thread_manager/src/ThreadManager.h
+++ b/thread_manager/src/ThreadManager.h
@@ -25,13 +25,16 @@ namespace thread_manager {
   public:
     ThreadManager();
 
+    bool processTick();
     void add(ThreadSubject *);
     void start();
+    bool startMono();
     void stop();
     void pause();
     void resume();
 
     void listen();
+    void listenMono();
   };
 
 }

--- a/thread_manager/src/ThreadSubject.cpp
+++ b/thread_manager/src/ThreadSubject.cpp
@@ -1,6 +1,8 @@
 #include "ThreadSubject.h"
+#include <thread>
 
-static const int threadManagerSleep = 100;
+using std::chrono::milliseconds;
+using std::this_thread::sleep_for;
 
 using std::shared_ptr;
 using std::make_shared;
@@ -16,6 +18,7 @@ ThreadSubject::ThreadSubject() {
   this->_commands = make_shared<queue<Command>>();
   this->_willStop = false;
   this->_paused = false;
+  this->_sleepThread = 50;
 
   static shared_ptr<queue<Command>> _commandsAfterInit = make_shared<queue<Command>>();
   static bool _threadInit = false;
@@ -66,4 +69,18 @@ void ThreadSubjectWithKill::_sendKill() {
     this->id(), ID::WINDOW_FACADE,
     CommandType::KILL);
   _commandManager->push(commandKill);
+}
+
+bool ThreadSubject::initialize() {
+  return true;
+}
+
+void ThreadSubject::start() {
+  if(!initialize()) return;
+  while(!this->_willStop) {
+    auto a = std::chrono::milliseconds(_sleepThread);
+    std::this_thread::sleep_for(a);
+
+    processTick();
+  }
 }

--- a/thread_manager/src/ThreadSubject.h
+++ b/thread_manager/src/ThreadSubject.h
@@ -18,14 +18,17 @@ namespace thread_manager {
 
     bool _willStop;
     bool _paused;
+    int _sleepThread;
   public:
     ThreadSubject();
+    virtual bool initialize();
+    virtual void processTick() = 0;
 
     std::shared_ptr<std::queue<command_manager::Command>> getQueueLink();
     virtual command_manager::ID id() = 0;
 
     virtual void stop() = 0;
-    virtual void start() = 0;
+    void start();
 
     void bind(command_manager::CommandManager*);
 


### PR DESCRIPTION
Цель введения однопоточного режима - многопоточная не потокобезопасная.
При частом обмене командами, например, на нажатие клавиш, система будет падать. пока commandManager не станет потокобезопасным. На данный момент было предложено не решать проблему бага, а завести однопоточный режим, чтобы продолжить работу над остальными задачами, видеть результат и функциональность, пока не будет устранена проблема протокобезопасности. Поэтому предлагаю этим пр перевести всё на рельсы одного потока, т.к. решить это всё качественно - сложная задача, которая не позволит даже треугольник затестить нормально.

Да, мы хотели, чтобы тм сам заводил потоки, решал кого с кем объединить, но у до этого пр у нас только крайне-многопоточная система была, пусть теперь будет крайне-однопоточная. 

Напомню, что однопоточная хотя бы работает и не падает.

Что сделано:
- функция start() теперь не виртуальная. 
- _sleepThread - переменная для сна в многопоточной системе.
- processTick() в каждом треаде. 

Запускаем 
- либо через startMono() -> listenMono()
- либо start() -> listen();
